### PR TITLE
Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -82,13 +82,18 @@ graph TB
 
 ### Use it with [Pelican](https://getpelican.com/)
 
-Add `"markdown_mermaidjs": {}` to `MARKDOWN["extension_configs"]` in your `pelicanconf.py`
+Add `"markdown_mermaidjs": {}` to `MARKDOWN["extension_configs"]` in your `pelicanconf.py`.
+For the default `MARKDOWN` configuration, it will look like the string below:
 
 ```python
 MARKDOWN = {
-    "extension_configs": {
-        "markdown_mermaidjs": {},
+    'extension_configs': {
+        'markdown.extensions.codehilite': {'css_class': 'highlight'},
+        'markdown.extensions.extra': {},
+        'markdown.extensions.meta': {},
+        "markdown_mermaidjs": {}, # <------ Our addition!
     },
+    'output_format': 'html5',
 }
 ```
 


### PR DESCRIPTION
Better explanation of how to enable in pelicanconf.py

## Types of changes
- **Documentation Update**

## Description
Using:

```python
MARKDOWN = {
    "extension_configs": {
        "markdown_mermaidjs": {},
    },
}
```
Overrides the most common `MARKDOWN` configuration, _i.e.:_, the default one. This causes problems (for instance, disables code highlighting). It is better to provide a default `MARKDOWN` configuration with the new line appended, that would be:

```python
MARKDOWN = {
    'extension_configs': {
        'markdown.extensions.codehilite': {'css_class': 'highlight'},
        'markdown.extensions.extra': {},
        'markdown.extensions.meta': {},
        "markdown_mermaidjs": {}, # <<<<<<<
    },
    'output_format': 'html5',
}
```

## Checklist:
- [ ] Add test cases to all the changes you introduce
- [ ] Run `inv style` locally to ensure all linter checks pass
- [ ] Run `inv test` locally to ensure all test cases pass
- [ ] Run `inv secure` locally to ensure no major vulnerability is introduced
- [x] Update the documentation if necessary
